### PR TITLE
fix java build by using java 8 not 11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-10
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-19 --no-ui -a
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-3 --no-ui -a
 
+RUN update-java-alternatives --set java-1.8.0-openjdk-amd64
+
 # Pre-cache Maven artifacts
 RUN git clone https://github.com/rapid7/metasploit-payloads.git && \
 	cd metasploit-payloads/java && make ; cd .. && rm -fr metasploit-payloads


### PR DESCRIPTION
This is required to fix:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.0:compile (default-compile) on project Metasploit-JavaPayload: Compilation failure: Compilation failure:
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :Metasploit-JavaPayload
```

Let me know if you want me to PR this to the master branch instead (it's not really related to cross compilation).